### PR TITLE
Add GitHub Actions steps to publish to both Github and NPM registry

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -43,3 +43,16 @@ jobs:
       env:
         # replace ${GITHUB_TOKEN} in .npmrc
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+    # Publish to NPM registry
+    - name: Publish to NPM Registry
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        registry-url: https://registry.npmjs.org/
+      run: |
+        rm .npmrc
+        echo //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN > .npmrc
+        npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -46,10 +46,6 @@ jobs:
 
     # Publish to NPM registry
     - name: Publish to NPM Registry
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-        registry-url: https://registry.npmjs.org/
       run: |
         rm .npmrc
         echo //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN > .npmrc

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -45,6 +45,12 @@ jobs:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
     # Publish to NPM registry
+    - name: Use Node.js ${{ matrix.node-version }} for NPM
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        registry-url: https://registry.npmjs.org/
+
     - name: Publish to NPM Registry
       run: |
         rm .npmrc


### PR DESCRIPTION
Changes since version v0.2.3

* publish to NPM registry will be under organziation geodacenter:  @geodacenter/jsgeoda v0.2.3 See https://www.npmjs.com/org/geodacenter

* publish to Github npm registry will be under organization geodacenter: @geodacenter/jsgeoda v0.2.3

